### PR TITLE
fix: window is undefined when visiting a /p/[userId]

### DIFF
--- a/packages/app/src/lib/components/common/interactive-zap-button.svelte
+++ b/packages/app/src/lib/components/common/interactive-zap-button.svelte
@@ -38,7 +38,7 @@
 	let zapDialogOpen = false
 	let spinnerShown = false
 	let advancedSettingsOpen = false
-	let canUseWebln = 'webln' in window
+	let canUseWebln = typeof window !== 'undefined' ? 'webln' in window : false
 
 	$: zapAmountSats = 21
 	$: user = $ndkStore.getUser({ pubkey: userIdToZap })


### PR DESCRIPTION
Resolves #370

```
packages/app dev: ReferenceError: window is not defined
packages/app dev:     at /home/aslemammad/work/plebeian.market/packages/app/src/lib/components/common/interactive-zap-button.svelte:41:31
packages/app dev:     at Object.$$render (/home/aslemammad/work/plebeian.market/node_modules/.pnpm/svelte@4.2.19/node_modules/svelte/src/runtime/internal/ssr.js:134:16)
packages/app dev:     at eval (/home/aslemammad/work/plebeian.market/packages/app/src/routes/p/[id]/+page.svelte:187:106)
packages/app dev:     at eval (/home/aslemammad/work/plebeian.market/packages/app/src/routes/p/[id]/+page.svelte:212:5)
packages/app dev:     at Object.$$render (/home/aslemammad/work/plebeian.market/node_modules/.pnpm/svelte@4.2.19/node_modules/svelte/src/runtime/internal/ssr.js:134:16)
packages/app dev:     at Object.default (/home/aslemammad/work/plebeian.market/packages/app/.svelte-kit/generated/root.svelte:50:51)
packages/app dev:     at /home/aslemammad/work/plebeian.market/packages/app/src/routes/p/[id]/+layout.svelte:5:65
packages/app dev:     at Object.$$render (/home/aslemammad/work/plebeian.market/node_modules/.pnpm/svelte@4.2.19/node_modules/svelte/src/runtime/internal/ssr.js:134:16)
packages/app dev:     at Object.default (/home/aslemammad/work/plebeian.market/packages/app/.svelte-kit/generated/root.svelte:49:46)
packages/app dev:     at Object.default (/home/aslemammad/work/plebeian.market/packages/app/src/routes/+layout.svelte:193:258)

```

I got this error occasionally and I fixed it this way, because in SSR, there's no window! 